### PR TITLE
Raspberry Pi にデプロイできるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ HttpProxy: https://xxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod/notifi
 curl -X POST -H "Accept: application/json" -H 'Content-Type: application/json' -d '{"text":"Hello world"}' https://xxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod/notifications
 ```
 
+## Deployment
+
+```shell
+npm run deploy
+```
+
 ## License
 
 See [LICENSE](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ curl -X POST -H "Accept: application/json" -H 'Content-Type: application/json' -
 npm run deploy
 ```
 
+### Execute commands
+
+```shell
+npx pm2 deploy production exec 'npx pm2 logs'
+```
+
+```shell
+npx pm2 deploy production exec 'tail log/production.log'
+```
+
 ## License
 
 See [LICENSE](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ npm run deploy
 ### Execute commands
 
 ```shell
+npx pm2 deploy production exec 'npx pm2 list'
+```
+
+```shell
 npx pm2 deploy production exec 'npx pm2 logs'
 ```
 

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -19,16 +19,14 @@ module.exports = {
     }
   ],
 
-  // FIXME: Not yet implemented
   deploy: {
     production: {
-      user: 'node',
-      host: '212.83.163.1',
+      user: 'pi',
+      host: 'raspberrypi',
       ref: 'origin/master',
-      repo: 'git@github.com:repo.git',
-      path: '/var/www/production',
-      'post-deploy':
-        'npm install && pm2 reload ecosystem.config.js --env production'
+      repo: 'git@github.com:inouetakuya/google-nest-notifier-api.git',
+      path: '/var/www/google-nest-notifier-api',
+      'post-deploy': 'npm install && npm run build && npm run reload'
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "reload": "pm2 reload ecosystem.config.js --env production",
     "restart": "pm2 restart ecosystem.config.js --env production",
     "stop": "pm2 stop ecosystem.config.js",
+    "deploy": "pm2 deploy ecosystem.config.js production",
     "dev": "nodemon",
     "lint": "eslint --ext .js,.ts --ignore-path .gitignore .",
     "lint:fix": "eslint --ext .js,.ts --ignore-path .gitignore . --fix",


### PR DESCRIPTION
Raspberry Pi にデプロイできるようにする

## Links

PM2 - Deployment
https://pm2.keymetrics.io/docs/usage/deployment/

- [Google Nest Notifier API をデプロイできるようにする by inouetakuya · Pull Request #9 · inouetakuya/pi-itamae](https://github.com/inouetakuya/pi-itamae/pull/9)