### PR TITLE
refactor: エラーハンドリングをカイゼンする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -238,6 +238,19 @@
         "minimist": "^1.2.0"
       }
     },
+    "@hapi/boom": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
+      "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "jest --verbose --runInBand --detectOpenHandles"
   },
   "dependencies": {
+    "@hapi/boom": "^9.1.0",
     "castv2-client": "^1.2.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ if (process.env.USE_DIST) require('module-alias/register')
 import ngrokService from '~/lib/ngrokService'
 import apiGatewayService from '~/lib/apiGatewayService'
 import notificationController from '~/lib/notificationController'
+import boomHandler from '~/lib/boomHandler'
 import errorHandler from '~/lib/errorHandler'
 
 dotenv.config()
@@ -38,6 +39,7 @@ app.use(morgan(logFormat, { stream: logStream }))
 
 app.post('/notifications', notificationController.create)
 
+app.use(boomHandler)
 app.use(errorHandler)
 
 const server = app.listen(process.env.PORT || 3000, async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ if (process.env.USE_DIST) require('module-alias/register')
 import ngrokService from '~/lib/ngrokService'
 import apiGatewayService from '~/lib/apiGatewayService'
 import notificationController from '~/lib/notificationController'
+import errorHandler from '~/lib/errorHandler'
 
 dotenv.config()
 
@@ -36,6 +37,8 @@ app.use(morgan(logFormat))
 app.use(morgan(logFormat, { stream: logStream }))
 
 app.post('/notifications', notificationController.create)
+
+app.use(errorHandler)
 
 const server = app.listen(process.env.PORT || 3000, async () => {
   const port = server.address().port

--- a/src/lib/apiGatewayService.ts
+++ b/src/lib/apiGatewayService.ts
@@ -2,6 +2,7 @@ import * as childProcess from 'child_process'
 
 // @ts-ignore TS7016: Could not find a declaration file for module 'proper-url-join'
 import urlJoin from 'proper-url-join'
+import { badData } from '@hapi/boom'
 
 interface ApiGatewayOptions {
   region: string
@@ -32,12 +33,12 @@ const apiGatewayService = {
     path?: string
     profile?: string
   }): string => {
-    if (!region) throw new Error('API Gateway region is required')
-    if (!restApiId) throw new Error('API Gateway restApiId is required')
-    if (!resourceId) throw new Error('API Gateway resourceId is required')
-    if (!httpMethod) throw new Error('API Gateway httpMethod is required')
-    if (!url) throw new Error('API Gateway url is required')
-    if (!path) throw new Error('API Gateway path is required')
+    if (!region) throw badData('API Gateway region is required')
+    if (!restApiId) throw badData('API Gateway restApiId is required')
+    if (!resourceId) throw badData('API Gateway resourceId is required')
+    if (!httpMethod) throw badData('API Gateway httpMethod is required')
+    if (!url) throw badData('API Gateway url is required')
+    if (!path) throw badData('API Gateway path is required')
 
     const apiGatewayOptions: ApiGatewayOptions = {
       region,

--- a/src/lib/boomHandler.ts
+++ b/src/lib/boomHandler.ts
@@ -11,7 +11,8 @@ const boomHandler = (
 
   response.status(error.output.statusCode).json({
     error: error.output.payload.error,
-    message: error.output.payload.message
+    message: error.message,
+    data: error.data || {}
   })
 }
 

--- a/src/lib/boomHandler.ts
+++ b/src/lib/boomHandler.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from 'express'
+import { Boom } from '@hapi/boom'
+
+const boomHandler = (
+  error: Boom,
+  request: Request,
+  response: Response,
+  next: NextFunction
+) => {
+  if (!error.isBoom) return next(error)
+
+  response.status(error.output.statusCode).json({
+    error: error.output.payload.error,
+    message: error.output.payload.message
+  })
+}
+
+export default boomHandler

--- a/src/lib/errorHandler.ts
+++ b/src/lib/errorHandler.ts
@@ -6,7 +6,10 @@ const errorHandler = (
   response: Response,
   next: NextFunction
 ) => {
-  response.status(500).json({ error: error.message })
+  response.status(500).json({
+    error: 'Internal Server Error',
+    message: error.message
+  })
 }
 
 export default errorHandler

--- a/src/lib/errorHandler.ts
+++ b/src/lib/errorHandler.ts
@@ -8,7 +8,8 @@ const errorHandler = (
 ) => {
   response.status(500).json({
     error: 'Internal Server Error',
-    message: error.message
+    message: error.message,
+    data: {}
   })
 }
 

--- a/src/lib/errorHandler.ts
+++ b/src/lib/errorHandler.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express'
+
+const errorHandler = (
+  error: Error,
+  request: Request,
+  response: Response,
+  next: NextFunction
+) => {
+  response.status(500).json({ error: error.message })
+}
+
+export default errorHandler

--- a/src/lib/notificationController.ts
+++ b/src/lib/notificationController.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express'
+import { badData, notFound } from '@hapi/boom'
 import { queryMulticastDnsDataByDeviceNames } from '~/lib/multicastDnsService'
 import textToSpeechUrl from '~/lib/textToSpeechUrl'
 import GoogleNestClient from '~/lib/GoogleNestClient'
@@ -8,19 +9,18 @@ const notificationController = {
     ;(async () => {
       const deviceNames = request.body.deviceNames
       if (!Array.isArray(deviceNames) || deviceNames.length === 0) {
-        throw new Error('deviceNames is required')
+        throw badData('deviceNames is required')
       }
 
       const text = request.body.text
-      if (!text) throw new Error('text is required')
+      if (!text) throw badData('text is required')
 
       const multicastDnsDataArray = await queryMulticastDnsDataByDeviceNames(
         deviceNames
       )
 
       if (multicastDnsDataArray.length === 0) {
-        // throw new Error('Google Nest Device is not found')
-        throw new Error(deviceNames[0])
+        throw notFound(`deviceName: ${deviceNames[0]} is not found`)
       }
 
       const speechUrl: string = await textToSpeechUrl({

--- a/src/lib/notificationController.ts
+++ b/src/lib/notificationController.ts
@@ -9,18 +9,21 @@ const notificationController = {
     ;(async () => {
       const deviceNames = request.body.deviceNames
       if (!Array.isArray(deviceNames) || deviceNames.length === 0) {
-        throw badData('deviceNames is required')
+        throw badData('deviceNames is required', { requestBody: request.body })
       }
 
       const text = request.body.text
-      if (!text) throw badData('text is required')
+      if (!text)
+        throw badData('text is required', { requestBody: request.body })
 
       const multicastDnsDataArray = await queryMulticastDnsDataByDeviceNames(
         deviceNames
       )
 
       if (multicastDnsDataArray.length === 0) {
-        throw notFound(`deviceName: ${deviceNames[0]} is not found`)
+        throw notFound('Google Nest Device is not found', {
+          deviceNames: request.body.deviceNames
+        })
       }
 
       const speechUrl: string = await textToSpeechUrl({

--- a/test/lib/notificationController.spec.ts
+++ b/test/lib/notificationController.spec.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import httpMocks, { MockRequest, MockResponse } from 'node-mocks-http'
 import { Request, Response } from 'express'
+import { badData } from '@hapi/boom'
 import notificationController from '~/lib/notificationController'
 
 const mockedStatus = { volume: { muted: false } }
@@ -72,9 +73,7 @@ describe('notificationController', () => {
 
       test('calls next() with Error', () => {
         response.on('end', done => {
-          expect(next).toHaveBeenCalledWith(
-            new Error('deviceNames is required')
-          )
+          expect(next).toHaveBeenCalledWith(badData('deviceNames is required'))
           done()
         })
 
@@ -95,7 +94,7 @@ describe('notificationController', () => {
 
       test('calls next() with Error', () => {
         response.on('end', done => {
-          expect(next).toHaveBeenCalledWith(new Error('text is required'))
+          expect(next).toHaveBeenCalledWith(badData('text is required'))
           done()
         })
 


### PR DESCRIPTION
Express でのエラー処理
https://expressjs.com/ja/guide/error-handling.html

Express の冗長なエラー処理を簡潔にする - Qiita
https://qiita.com/azujuuuuuun/items/f0be4a71aca2d92036aa

hapijs/boom: HTTP-friendly error objects
https://github.com/hapijs/boom